### PR TITLE
Reverted prior to DI and Json'd two messages

### DIFF
--- a/Controllers/CameraController.cs
+++ b/Controllers/CameraController.cs
@@ -112,10 +112,10 @@ namespace EyesOnTheNet.Controllers
 
             if (isRecording)
             {
-                return Ok("Recording Started");
+                return Ok( "{\"Recording Started\": true}");
             }
 
-            return StatusCode(417, "Invalid Camera");
+            return StatusCode(417, "{\"Invalid Camera\": true}");
         }
 
         [HttpGet("api/[controller]/displaytasks")]


### PR DESCRIPTION
The DI in .NET Core was disposing prior to completion of the actual methods so I reverted back to instantiated classes to fix it.